### PR TITLE
Create image convertor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,9 @@
 /src/tmp
 /.pnp
 .pnp.js
+# This two probably should not be ignored
 pnpm-lock.yaml
+package-lock.json
 
 # testing
 /coverage

--- a/api/Cargo.lock
+++ b/api/Cargo.lock
@@ -3,10 +3,40 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
+name = "autocfg"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bumpalo"
 version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
+
+[[package]]
+name = "bytemuck"
+version = "1.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
@@ -15,16 +45,102 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "jpeg-decoder",
+ "num-traits",
+ "png",
+]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
+
+[[package]]
 name = "log"
 version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "png"
+version = "0.17.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82151a2fc869e011c153adc57cf2789ccb8d9906ce52c0b39a6b5697749d7526"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -51,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
 name = "syn"
 version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -71,6 +193,7 @@ checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 name = "wasm-api"
 version = "0.1.0"
 dependencies = [
+ "image",
  "wasm-bindgen",
 ]
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -8,3 +8,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wasm-bindgen = "0.2"
+image = { version = "0.24", default-features = false, features = ["png", "jpeg"] }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -11,3 +11,13 @@ pub fn to_grayscale(image: &[u8]) -> Vec<u8> {
     gray.write_to(&mut buf, ImageOutputFormat::Png).unwrap();
     buf.into_inner()
 }
+
+#[wasm_bindgen]
+pub fn invert_colors(image: &[u8]) -> Vec<u8> {
+    let mut img = image::load_from_memory(image).unwrap();
+    img.invert();
+
+    let mut buf = Cursor::new(Vec::new());
+    img.write_to(&mut buf, ImageOutputFormat::Png).unwrap();
+    buf.into_inner()
+}

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -1,6 +1,13 @@
+use image::ImageOutputFormat;
+use std::io::Cursor;
 use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
-pub fn update_button_text() -> String {
-    "Clicked from Rust!".into()
+pub fn to_grayscale(image: &[u8]) -> Vec<u8> {
+    let img = image::load_from_memory(image).unwrap();
+    let gray = img.grayscale();
+
+    let mut buf = Cursor::new(Vec::new());
+    gray.write_to(&mut buf, ImageOutputFormat::Png).unwrap();
+    buf.into_inner()
 }

--- a/client/package.json
+++ b/client/package.json
@@ -11,7 +11,8 @@
     "deploy": "vite build && gh-pages -d dist"
   },
   "dependencies": {
-    "preact": "^10.26.5"
+    "preact": "^10.26.5",
+    "react-select": "^5.10.1"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.10.1",

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,0 +1,7 @@
+body {
+  font-family: system-ui, sans-serif;
+  background: #f8f9fa;
+  margin: 0;
+  padding: 2rem;
+  color: #333;
+}

--- a/client/src/app.jsx
+++ b/client/src/app.jsx
@@ -1,19 +1,15 @@
-import { useState } from 'preact/hooks';
-import init, { update_button_text } from './wasm/wasm_api.js';
+import "./app.css";
+import ImageConverter from "./images/ImageConverter.jsx";
+import { useWasm } from "./useWasm.js";
 
 export function App() {
-  const [text, setText] = useState('Click me!');
-  
-  const handleClick = async () => {
-    await init();
-    const newText = update_button_text();
-    setText(newText);
-  };
+  const { wasmReady, wasmError } = useWasm();
+  console.log("WASM ready:", wasmReady);
 
   return (
     <div>
-      <div>Rust WASM project demo</div>
-      <button onClick={handleClick}>{text}</button>
+      {wasmError && <p>Error initializing WASM: {wasmError.message}</p>}
+      <ImageConverter />
     </div>
   );
 }

--- a/client/src/images/ImageConverter.css
+++ b/client/src/images/ImageConverter.css
@@ -54,6 +54,27 @@
   cursor: not-allowed;
 }
 
+.conversion-select {
+  padding: 0.5rem 1.25rem;
+  font-size: 0.95rem;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background-color: white;
+  color: #333;
+  cursor: pointer;
+  transition: border-color 0.3s ease, box-shadow 0.3s ease;
+}
+
+.conversion-select:focus {
+  outline: none;
+  border-color: #007bff;
+  box-shadow: 0 0 0 2px rgba(0, 123, 255, 0.25);
+}
+
+.conversion-select:hover {
+  border-color: #888;
+}
+
 .image-preview-container {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));

--- a/client/src/images/ImageConverter.css
+++ b/client/src/images/ImageConverter.css
@@ -1,0 +1,78 @@
+.image-converter {
+  max-width: 100%;
+  margin: 0 auto;
+  padding: 2rem;
+  background: white;
+  border-radius: 1rem;
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.image-converter-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  margin-bottom: 2rem;
+}
+
+.image-converter-header h1 {
+  font-size: 2rem;
+  flex: 1 1 auto;
+  margin: 0;
+  color: #333;
+}
+
+.image-converter-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.image-converter-controls input[type="file"] {
+  display: none;
+}
+
+.image-converter-controls button {
+  padding: 0.5rem 1.25rem;
+  font-size: 0.95rem;
+  background-color: #007bff;
+  border: none;
+  border-radius: 6px;
+  color: white;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.image-converter-controls button:hover:not(:disabled) {
+  background-color: #0056b3;
+}
+
+.image-converter-controls button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}
+
+.image-preview-container {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.upload-label {
+  display: inline-block;
+  padding: 0.5rem 1.25rem;
+  background-color: #28a745;
+  color: white;
+  border-radius: 6px;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease;
+}
+
+.upload-label:hover {
+  background-color: #218838;
+}

--- a/client/src/images/ImageConverter.jsx
+++ b/client/src/images/ImageConverter.jsx
@@ -1,8 +1,25 @@
 import "./ImageConverter.css";
 import { useState } from "preact/hooks";
+import Select from "react-select";
 import { useWasm } from "../useWasm.js";
-import { to_grayscale } from "../wasm/wasm_api.js";
+import { to_grayscale, invert_colors } from "../wasm/wasm_api.js";
 import ImagePreview from "./ImagePreview.jsx";
+
+const options = [
+  { value: "grayscale", label: "Grayscale" },
+  { value: "invert", label: "Invert" },
+];
+
+function convert(rawBytes, conversionType) {
+  switch (conversionType) {
+    case "grayscale":
+      return to_grayscale(rawBytes);
+    case "invert":
+      return invert_colors(rawBytes);
+    default:
+      throw new Error("Unsupported conversion type");
+  }
+}
 
 const ImageConverter = () => {
   const { wasmReady } = useWasm();
@@ -10,6 +27,7 @@ const ImageConverter = () => {
   const [imgResult, setImgResult] = useState(null);
   const [rawBytes, setRawBytes] = useState(null);
   const [previesAspectRatios, setPreviesAspectRatios] = useState(16 / 10);
+  const [conversionType, setConversionType] = useState(null);
 
   const handleUpload = async (e) => {
     const file = e.target.files?.[0];
@@ -25,8 +43,7 @@ const ImageConverter = () => {
 
   const handleConvert = async () => {
     if (!rawBytes || !wasmReady) return;
-    const output = to_grayscale(rawBytes);
-
+    const output = convert(rawBytes, conversionType.value);
     const blob = new Blob([output], { type: "image/png" });
     setImgResult(URL.createObjectURL(blob));
   };
@@ -39,8 +56,31 @@ const ImageConverter = () => {
           <label for='image-upload' className='upload-label'>
             Upload Image
           </label>
-          <button onClick={handleConvert} disabled={!wasmReady || !rawBytes}>
-            Convert to Grayscale
+          <Select
+            value={conversionType}
+            onChange={(opt) => setConversionType(opt)}
+            options={options}
+            styles={{
+              control: (base) => ({
+                ...base,
+                borderRadius: "6px",
+                borderColor: "#ccc",
+                boxShadow: "none",
+                minWidth: "150px",
+                "&:hover": { borderColor: "#888" },
+              }),
+              option: (base, { isFocused }) => ({
+                ...base,
+                backgroundColor: isFocused ? "#f0f0f0" : "white",
+                color: "#333",
+              }),
+            }}
+          />
+          <button
+            onClick={handleConvert}
+            disabled={!wasmReady || !rawBytes || !conversionType}
+          >
+            Convert
           </button>
           <input
             id='image-upload'
@@ -65,7 +105,7 @@ const ImageConverter = () => {
           setAspectRatio={setPreviesAspectRatios}
           emptyText={
             imgSrc
-              ? "Press select conversion type and press 'Convert'."
+              ? "Select conversion type and press 'Convert'"
               : "No image selected"
           }
         />

--- a/client/src/images/ImageConverter.jsx
+++ b/client/src/images/ImageConverter.jsx
@@ -1,0 +1,77 @@
+import "./ImageConverter.css";
+import { useState } from "preact/hooks";
+import { useWasm } from "../useWasm.js";
+import { to_grayscale } from "../wasm/wasm_api.js";
+import ImagePreview from "./ImagePreview.jsx";
+
+const ImageConverter = () => {
+  const { wasmReady } = useWasm();
+  const [imgSrc, setImgSrc] = useState(null);
+  const [imgResult, setImgResult] = useState(null);
+  const [rawBytes, setRawBytes] = useState(null);
+  const [previesAspectRatios, setPreviesAspectRatios] = useState(16 / 10);
+
+  const handleUpload = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    const arrayBuffer = await file.arrayBuffer();
+    const bytes = new Uint8Array(arrayBuffer);
+    setRawBytes(bytes);
+
+    const blob = new Blob([bytes]);
+    setImgSrc(URL.createObjectURL(blob));
+  };
+
+  const handleConvert = async () => {
+    if (!rawBytes || !wasmReady) return;
+    const output = to_grayscale(rawBytes);
+
+    const blob = new Blob([output], { type: "image/png" });
+    setImgResult(URL.createObjectURL(blob));
+  };
+
+  return (
+    <div className='image-converter'>
+      <div className='image-converter-header'>
+        <h1>Image Converter</h1>
+        <div className='image-converter-controls'>
+          <label for='image-upload' className='upload-label'>
+            Upload Image
+          </label>
+          <button onClick={handleConvert} disabled={!wasmReady || !rawBytes}>
+            Convert to Grayscale
+          </button>
+          <input
+            id='image-upload'
+            type='file'
+            accept='image/*'
+            onChange={handleUpload}
+          />
+        </div>
+      </div>
+      <div className='image-preview-container'>
+        <ImagePreview
+          imageUrl={imgSrc}
+          header={"Original Image"}
+          aspectRatio={previesAspectRatios}
+          setAspectRatio={setPreviesAspectRatios}
+          emptyText={"No image selected"}
+        />
+        <ImagePreview
+          imageUrl={imgResult}
+          header={"Converted Image"}
+          aspectRatio={previesAspectRatios}
+          setAspectRatio={setPreviesAspectRatios}
+          emptyText={
+            imgSrc
+              ? "Press select conversion type and press 'Convert'."
+              : "No image selected"
+          }
+        />
+      </div>
+    </div>
+  );
+};
+
+export default ImageConverter;

--- a/client/src/images/ImagePreview.css
+++ b/client/src/images/ImagePreview.css
@@ -1,0 +1,29 @@
+.image-preview {
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.image-preview h2 {
+  margin-bottom: 1rem;
+  font-size: 1rem;
+  text-align: center;
+}
+
+.image-preview img,
+.empty-preview {
+  width: 100%;
+  object-fit: contain;
+  border-radius: 0.5rem;
+  background-color: #f9f9f9;
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.empty-preview {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border: 2px dashed #ddd;
+  background-color: #f9f9f9;
+}

--- a/client/src/images/ImagePreview.jsx
+++ b/client/src/images/ImagePreview.jsx
@@ -1,0 +1,49 @@
+import { useEffect, useRef, useState } from "preact/hooks";
+import "./ImagePreview.css";
+
+const ImagePreview = ({
+  imageUrl,
+  header,
+  emptyText,
+  aspectRatio,
+  setAspectRatio,
+}) => {
+  const imgRef = useRef(null);
+
+  useEffect(() => {
+    if (!imageUrl || !imgRef.current) return;
+
+    const img = imgRef.current;
+
+    const updateAspect = () => {
+      if (img.naturalWidth && img.naturalHeight) {
+        setAspectRatio(img.naturalWidth / img.naturalHeight);
+      }
+    };
+
+    if (img.complete) {
+      updateAspect();
+    } else {
+      img.onload = updateAspect;
+    }
+  }, [imageUrl]);
+
+  const previewStyle = {
+    aspectRatio: aspectRatio.toFixed(5),
+  };
+
+  return (
+    <div className='image-preview'>
+      {header && <h2>{header}</h2>}
+      {imageUrl ? (
+        <img ref={imgRef} src={imageUrl} alt='Preview' style={previewStyle} />
+      ) : (
+        <div className='empty-preview' style={previewStyle}>
+          <p>{emptyText || "No image available"}</p>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default ImagePreview;

--- a/client/src/images/ImagePreview.jsx
+++ b/client/src/images/ImagePreview.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "preact/hooks";
+import { useEffect, useRef } from "preact/hooks";
 import "./ImagePreview.css";
 
 const ImagePreview = ({

--- a/client/src/useWasm.js
+++ b/client/src/useWasm.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "preact/hooks";
+import init from "./wasm/wasm_api.js";
+
+export function useWasm() {
+  const [wasmReady, setWasmReady] = useState(false);
+  const [wasmError, setWasmError] = useState(null);
+
+  useEffect(() => {
+    const loadWasm = async () => {
+      try {
+        await init();
+        setWasmReady(true);
+      } catch (error) {
+        setWasmError(error);
+      }
+    };
+
+    loadWasm();
+  }, []);
+
+  return { wasmReady, wasmError };
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,11 +1,17 @@
-import { defineConfig } from 'vite'
-import preact from '@preact/preset-vite'
+import { defineConfig } from "vite";
+import preact from "@preact/preset-vite";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [preact()],
-  base: '/rustoscope/',
+  base: "/rustoscope/",
+  resolve: {
+    alias: {
+      react: "preact/compat",
+      "react-dom": "preact/compat",
+    },
+  },
   build: {
-    outDir: 'dist'
-  }
-})
+    outDir: "dist",
+  },
+});


### PR DESCRIPTION
Create image convertor
-

In this PR I set up simple image convertor UI. Features introduced:

-  Upload image from local machine
-  Display image on preview
-  Create conversion type selector to allow multiple conversion types
-  Convert images on Rust side and display result preview

<img width="800" alt="image" src="https://github.com/user-attachments/assets/2884248c-fb58-4795-8835-5770cfdfc2f2" />
